### PR TITLE
Support app/concepts/:namespace/operation/... structure

### DIFF
--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -5,7 +5,7 @@ module Trailblazer
     # Please note that this is subject to change - we're still finding out the best way
     # to explicitly load files.
     def call(app_root)
-      operations = Dir.glob("app/concepts/**/operation.rb").sort { |a, b| a.split("/").size <=> b.split("/").size }
+      operations = Dir.glob("app/concepts/**/operation*").sort { |a, b| a.split("/").size <=> b.split("/").size }
       # lame heuristic, but works for me: sort by nested levels.
       # app/concepts/comment
       # app/concepts/api/v1/comment
@@ -14,7 +14,7 @@ module Trailblazer
 
       operations.each do |f|
         path  = f.sub("app/concepts/", "")
-        model = path.sub("/operation.rb", "")
+        model = path.sub("/operation","").chomp(".rb")
 
         concept = model # comment, api/v1/comment, ...
 
@@ -32,9 +32,8 @@ module Trailblazer
           yield file if File.exist?("#{file}.rb") # load the model file, first (thing.rb).
         end
 
-
         # concepts/:namespace/operation.rb
-        yield "#{app_root}/#{f}" # load app/concepts/{concept}/crud.rb (Thing::Create, Thing::Update, and so on).
+        yield "#{app_root}/#{f}" if File.exists?("#{app_root}/#{f}.rb")
       end
     end
   end

--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -36,7 +36,7 @@ module Trailblazer
         yield "#{app_root}/#{f}" if File.exists?("#{app_root}/#{f}.rb")
 
         if Dir.exists?(f)
-            Dir.glob("#{f}/**/*.rb").each do |operation|
+            Dir.glob("#{app_root}/#{f}/**/*.rb").each do |operation|
               yield operation.chomp('.rb')
             end
         end

--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -34,6 +34,12 @@ module Trailblazer
 
         # concepts/:namespace/operation.rb
         yield "#{app_root}/#{f}" if File.exists?("#{app_root}/#{f}.rb")
+
+        if Dir.exists?(f)
+            Dir.glob("#{f}/**/*.rb").each do |operation|
+              yield operation.chomp('.rb')
+            end
+        end
       end
     end
   end


### PR DESCRIPTION
Currently the loader requires the presence of an operation.rb file.
The readme show a structure where you use an operation folder.
This supports both.