### PR TITLE
Rework sorting, so operations are in alphabetical order

### DIFF
--- a/test/trailblazer/loader_test.rb
+++ b/test/trailblazer/loader_test.rb
@@ -5,7 +5,42 @@ class Trailblazer::LoaderTest < Minitest::Test
     refute_nil ::Trailblazer::Loader::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_ordering
+    input = [
+      "app/concepts/order/cell/index.rb",
+      "app/concepts/order/operation/update.rb",
+      "app/concepts/order/cell/part.rb",
+      "app/concepts/order/operation/index.rb",
+      "app/concepts/order/cell/update.rb",
+      "app/concepts/order/operation/search.rb",
+      "app/concepts/order/cell/create.rb",
+      "app/concepts/order/policy.rb",
+      "app/concepts/order/cell.rb",
+      "app/concepts/order/contract/update.rb",
+      "app/concepts/order/contract/create.rb",
+      "app/concepts/order/operation/from_traject.rb",
+      "app/concepts/order/operation/create.rb"
+    ]
+
+    expected = [
+      "app/concepts/order/cell.rb",
+      "app/concepts/order/cell/create.rb",
+      "app/concepts/order/cell/index.rb",
+      "app/concepts/order/cell/part.rb",
+      "app/concepts/order/cell/update.rb",
+      "app/concepts/order/contract/create.rb",
+      "app/concepts/order/contract/update.rb",
+      "app/concepts/order/policy.rb",
+      "app/concepts/order/operation/create.rb",
+      "app/concepts/order/operation/from_traject.rb",
+      "app/concepts/order/operation/index.rb",
+      "app/concepts/order/operation/search.rb",
+      "app/concepts/order/operation/update.rb"
+    ]
+
+    input = ::Trailblazer::Loader::SortCreateFirst.(input, {})
+    result = ::Trailblazer::Loader::SortOperationLast.(input, {})
+
+    assert_equal expected, result
   end
 end


### PR DESCRIPTION
I frist wanted to add my sort after FindConcepts, but that caused an error on line 24 where you hardcoded the index into pipeline, but that did not work.

So the sorting currently goes like this:
* SortCreateFirst orders everything alphabetically.
* SortOperationLast checks:
  * the left is an operation, move it
  * the right is an operation, leave it be
  * else sort.
