### PR TITLE
Fixed a concept files loading order sorting issue on Mac OS

### DIFF
--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -55,7 +55,7 @@ module Trailblazer
     end
 
     # operation files should be loaded after callbacks, policies, and the like: [callback.rb, contract.rb, policy.rb, operation.rb]
-    SortOperationLast = ->(input, options) { input.sort { |a, b| a =~ /operation/ && b !~ /operation/ ? 1 : a !~ /operation/ && b =~ /operation/ ? 0 : a <=> b  } }
+    SortOperationLast = ->(input, options) { input.sort { |a, b| a =~ /operation/ && b !~ /operation/ ? 1 : a !~ /operation/ && b =~ /operation/ ? -1 : a <=> b  } }
     SortCreateFirst   = ->(input, options) { input.sort }
     AddConceptFiles   = ->(input, options) { input }
 

--- a/test/trailblazer/loader_test.rb
+++ b/test/trailblazer/loader_test.rb
@@ -43,4 +43,41 @@ class Trailblazer::LoaderTest < Minitest::Test
 
     assert_equal expected, result
   end
+
+  def test_ordering_mac_osx
+    input = [
+      "app/models/user.rb",
+      "app/concepts/user/callback.rb",
+      "app/concepts/user/policy.rb",
+      "app/concepts/user/scope.rb",
+      "app/concepts/user/cell/row.rb",
+      "app/concepts/user/cell/table.rb",
+      "app/concepts/user/contract/create.rb",
+      "app/concepts/user/contract/update.rb",
+      "app/concepts/user/operation/create.rb",
+      "app/concepts/user/operation/index.rb",
+      "app/concepts/user/operation/show.rb",
+      "app/concepts/user/operation/update.rb"
+    ]
+
+    expected = [
+      "app/concepts/user/callback.rb",
+      "app/concepts/user/cell/row.rb",
+      "app/concepts/user/cell/table.rb",
+      "app/concepts/user/contract/create.rb",
+      "app/concepts/user/contract/update.rb",
+      "app/concepts/user/policy.rb",
+      "app/concepts/user/scope.rb",
+      "app/models/user.rb",
+      "app/concepts/user/operation/create.rb",
+      "app/concepts/user/operation/index.rb",
+      "app/concepts/user/operation/show.rb",
+      "app/concepts/user/operation/update.rb"
+    ]
+
+    input = ::Trailblazer::Loader::SortCreateFirst.(input, {})
+    result = ::Trailblazer::Loader::SortOperationLast.(input, {})
+
+    assert_equal expected, result
+  end
 end


### PR DESCRIPTION
Issue is occurring on _Mac OS X 10.11.2_ when operation files fail to load after callbacks.

The proposed modification sorts the files of a concept correctly so operation files are shifted to the end of the loading order list.

The proposed solution is tested both on Linux and OS X.
