### PR TITLE
Allow filenames including concept dir names

### DIFF
--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -40,7 +40,7 @@ module Trailblazer
 
     FindDirectories  = ->(input, options) { Dir.glob("#{options[:concepts_root]}**/") }
     # Filter out all directories containing /(callback|cell|contract|operation|policy|representer|view)/
-    FindConcepts     = ->(input, options) { input.shift; input.reject { |dir| dir =~ /(#{options[:concept_dirs].join("|")})/ } }
+    FindConcepts     = ->(input, options) { input.shift; input.reject { |dir| dir =~ /\A#{options[:concepts_root]}\/(#{options[:concept_dirs].join("|")})\/*/ } }
     PrintConcepts    = ->(input, options) { puts "  concepts: #{input.inspect}"; input }
 
     # lame heuristic, but works for me: sort by directory levels.

--- a/test/trailblazer/loader_test.rb
+++ b/test/trailblazer/loader_test.rb
@@ -43,4 +43,25 @@ class Trailblazer::LoaderTest < Minitest::Test
 
     assert_equal expected, result
   end
+
+  def test_naming
+    opts = {
+      concept_dirs: %w{ callback cell contract operation policy representer view },
+      concepts_root: "app/concepts"
+    }
+    input = [
+      "",
+      "app/concepts/foo_review/operation/update.rb",
+      "app/concepts/policy/operation/update.rb",
+      "app/concepts/review/cell/index.rb",
+      "app/concepts/order/cell/part.rb"
+    ]
+    expected = [
+      "app/concepts/foo_review/operation/update.rb",
+      "app/concepts/review/cell/index.rb",
+      "app/concepts/order/cell/part.rb"
+    ]
+    result = ::Trailblazer::Loader::FindConcepts.(input, opts)
+    assert_equal expected, result
+  end
 end


### PR DESCRIPTION
The way it works now is that if you have a directory in `app/concepts`
that contains a the name of a concept directory from the excludes list

```
%w{ callback cell contract operation policy representer view }

```

then it is excluded from the loader

I had for example a directory `app/concepts/reviews` which I imagine is
pretty common and it was never getting included and it was driving me
crazy >:(

This is in inelegant solution. Test is passing but needs to be prettier.