### PR TITLE
Removing fuzziness in concept loading

### DIFF
--- a/lib/trailblazer/loader.rb
+++ b/lib/trailblazer/loader.rb
@@ -40,13 +40,13 @@ module Trailblazer
 
     FindDirectories  = ->(input, options) { Dir.glob("#{options[:concepts_root]}**/") }
     # Filter out all directories containing /(callback|cell|contract|operation|policy|representer|view)/
-    FindConcepts     = ->(input, options) { input.shift; input.reject { |dir| dir =~ /(#{options[:concept_dirs].join("|")})/ } }
+    FindConcepts     = ->(input, options) { input.reject { (dir.split(File::SEPARATOR) & options[:concept_dirs]).any? } }
     PrintConcepts    = ->(input, options) { puts "  concepts: #{input.inspect}"; input }
 
     # lame heuristic, but works for me: sort by directory levels.
     # app/concepts/comment
     # app/concepts/api/v1/comment
-    SortByLevel  = ->(input, options) { input.sort { |a, b| a.split("/").size <=> b.split("/").size } }
+    SortByLevel  = ->(input, options) { input.sort { |a, b| a.split(File::SEPARATOR).size <=> b.split(File::SEPARATOR).size } }
     # Extract concept name from path, e.g. /api/v1/comment.
     ConceptName   = ->(input, options) { options[:name] = input.sub(options[:concepts_root], "").chomp("/"); [] }
     # Find all .rb files in one particular concept directory, e.g. as in /concepts/comment/*.rb.

--- a/test/trailblazer/loader_test.rb
+++ b/test/trailblazer/loader_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Trailblazer::LoaderTest < Minitest::Test
-  def test_that_it_has_a_version_number
+  def test_it_has_a_version_number
     refute_nil ::Trailblazer::Loader::VERSION
   end
 
@@ -19,7 +19,8 @@ class Trailblazer::LoaderTest < Minitest::Test
       "app/concepts/order/contract/update.rb",
       "app/concepts/order/contract/create.rb",
       "app/concepts/order/operation/from_traject.rb",
-      "app/concepts/order/operation/create.rb"
+      "app/concepts/order/operation/create.rb",
+      "app/concepts/contractor/operation.rb"
     ]
 
     expected = [
@@ -31,11 +32,12 @@ class Trailblazer::LoaderTest < Minitest::Test
       "app/concepts/order/contract/create.rb",
       "app/concepts/order/contract/update.rb",
       "app/concepts/order/policy.rb",
+      "app/concepts/contractor/operation.rb",
       "app/concepts/order/operation/create.rb",
       "app/concepts/order/operation/from_traject.rb",
       "app/concepts/order/operation/index.rb",
       "app/concepts/order/operation/search.rb",
-      "app/concepts/order/operation/update.rb"
+      "app/concepts/order/operation/update.rb",
     ]
 
     input = ::Trailblazer::Loader::SortCreateFirst.(input, {})


### PR DESCRIPTION
Targets #10. Current concept filtering logic rejects concepts that happens to include `cell` or `contract` - `contractor` concept will not be loaded. This is to fix it in Regex-free way. Test included.